### PR TITLE
Cherry-pick setts bitstream filter into 4.3.2 (from 4.4)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,9 @@
 Entries are sorted chronologically from oldest to youngest within each release,
 releases are sorted from youngest to oldest.
 
+version <next>:
+- setts bitstream filter
+
 version 4.3.2:
  avcodec/hapdec: Change compressed_offset to unsigned 32bit
  avformat/rmdec: Check codec_length without overflow

--- a/doc/bitstream_filters.texi
+++ b/doc/bitstream_filters.texi
@@ -727,6 +727,9 @@ The previous output PTS.
 
 @item TB
 The timebase of stream packet belongs.
+
+@item SR
+The sample rate of stream packet belongs.
 @end table
 
 @anchor{text2movsub}

--- a/doc/bitstream_filters.texi
+++ b/doc/bitstream_filters.texi
@@ -675,6 +675,60 @@ Remove extradata from all frames.
 @end table
 @end table
 
+@section setts
+Set PTS and DTS in packets.
+
+It accepts the following parameters:
+@table @option
+@item ts
+@item pts
+@item dts
+Set expressions for PTS, DTS or both.
+@end table
+
+The expressions are evaluated through the eval API and can contain the following
+constants:
+
+@table @option
+@item N
+The count of the input packet. Starting from 0.
+
+@item TS
+The demux timestamp in input in case of @code{ts} or @code{dts} option or presentation
+timestamp in case of @code{pts} option.
+
+@item POS
+The original position in the file of the packet, or undefined if undefined
+for the current packet
+
+@item DTS
+The demux timestamp in input.
+
+@item PTS
+The presentation timestamp in input.
+
+@item STARTDTS
+The DTS of the first packet.
+
+@item STARTPTS
+The PTS of the first packet.
+
+@item PREV_INDTS
+The previous input DTS.
+
+@item PREV_INPTS
+The previous input PTS.
+
+@item PREV_OUTDTS
+The previous output DTS.
+
+@item PREV_OUTPTS
+The previous output PTS.
+
+@item TB
+The timebase of stream packet belongs.
+@end table
+
 @anchor{text2movsub}
 @section text2movsub
 

--- a/doc/bitstream_filters.texi
+++ b/doc/bitstream_filters.texi
@@ -730,6 +730,9 @@ The timebase of stream packet belongs.
 
 @item SR
 The sample rate of stream packet belongs.
+
+@item NOPTS
+The AV_NOPTS_VALUE constant.
 @end table
 
 @anchor{text2movsub}

--- a/libavcodec/Makefile
+++ b/libavcodec/Makefile
@@ -1132,6 +1132,7 @@ OBJS-$(CONFIG_OPUS_METADATA_BSF)          += opus_metadata_bsf.o
 OBJS-$(CONFIG_PCM_RECHUNK_BSF)            += pcm_rechunk_bsf.o
 OBJS-$(CONFIG_PRORES_METADATA_BSF)        += prores_metadata_bsf.o
 OBJS-$(CONFIG_REMOVE_EXTRADATA_BSF)       += remove_extradata_bsf.o
+OBJS-$(CONFIG_SETTS_BSF)                  += setts_bsf.o
 OBJS-$(CONFIG_TEXT2MOVSUB_BSF)            += movsub_bsf.o
 OBJS-$(CONFIG_TRACE_HEADERS_BSF)          += trace_headers_bsf.o
 OBJS-$(CONFIG_TRUEHD_CORE_BSF)            += truehd_core_bsf.o mlp_parse.o mlp.o

--- a/libavcodec/bitstream_filters.c
+++ b/libavcodec/bitstream_filters.c
@@ -53,6 +53,7 @@ extern const AVBitStreamFilter ff_opus_metadata_bsf;
 extern const AVBitStreamFilter ff_pcm_rechunk_bsf;
 extern const AVBitStreamFilter ff_prores_metadata_bsf;
 extern const AVBitStreamFilter ff_remove_extradata_bsf;
+extern const AVBitStreamFilter ff_setts_bsf;
 extern const AVBitStreamFilter ff_text2movsub_bsf;
 extern const AVBitStreamFilter ff_trace_headers_bsf;
 extern const AVBitStreamFilter ff_truehd_core_bsf;

--- a/libavcodec/setts_bsf.c
+++ b/libavcodec/setts_bsf.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2021 Paul B Mahol
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * Change the PTS/DTS timestamps.
+ */
+
+#include "libavutil/opt.h"
+#include "libavutil/eval.h"
+
+#include "avcodec.h"
+#include "bsf.h"
+#include "bsf_internal.h"
+
+static const char *const var_names[] = {
+    "N",           ///< frame number (starting at zero)
+    "TS",
+    "POS",         ///< original position in the file of the frame
+    "PREV_INPTS",  ///< previous  input PTS
+    "PREV_INDTS",  ///< previous  input DTS
+    "PREV_OUTPTS", ///< previous output PTS
+    "PREV_OUTDTS", ///< previous output DTS
+    "PTS",         ///< original PTS in the file of the frame
+    "DTS",         ///< original DTS in the file of the frame
+    "STARTPTS",    ///< PTS at start of movie
+    "STARTDTS",    ///< DTS at start of movie
+    "TB",          ///< timebase of the stream
+    NULL
+};
+
+enum var_name {
+    VAR_N,
+    VAR_TS,
+    VAR_POS,
+    VAR_PREV_INPTS,
+    VAR_PREV_INDTS,
+    VAR_PREV_OUTPTS,
+    VAR_PREV_OUTDTS,
+    VAR_PTS,
+    VAR_DTS,
+    VAR_STARTPTS,
+    VAR_STARTDTS,
+    VAR_TB,
+    VAR_VARS_NB
+};
+
+typedef struct SetTSContext {
+    const AVClass *class;
+
+    char *ts_str;
+    char *pts_str;
+    char *dts_str;
+
+    int64_t frame_number;
+
+    int64_t start_pts;
+    int64_t start_dts;
+    int64_t prev_inpts;
+    int64_t prev_indts;
+    int64_t prev_outpts;
+    int64_t prev_outdts;
+
+    double var_values[VAR_VARS_NB];
+
+    AVExpr *ts_expr;
+    AVExpr *pts_expr;
+    AVExpr *dts_expr;
+} SetTSContext;
+
+static int setts_init(AVBSFContext *ctx)
+{
+    SetTSContext *s = ctx->priv_data;
+    int ret;
+
+    if ((ret = av_expr_parse(&s->ts_expr, s->ts_str,
+                             var_names, NULL, NULL, NULL, NULL, 0, ctx)) < 0) {
+        av_log(ctx, AV_LOG_ERROR, "Error while parsing ts expression '%s'\n", s->ts_str);
+        return ret;
+    }
+
+    if (s->pts_str) {
+        if ((ret = av_expr_parse(&s->pts_expr, s->pts_str,
+                                 var_names, NULL, NULL, NULL, NULL, 0, ctx)) < 0) {
+            av_log(ctx, AV_LOG_ERROR, "Error while parsing pts expression '%s'\n", s->pts_str);
+            return ret;
+        }
+    }
+
+    if (s->dts_str) {
+        if ((ret = av_expr_parse(&s->dts_expr, s->dts_str,
+                                 var_names, NULL, NULL, NULL, NULL, 0, ctx)) < 0) {
+            av_log(ctx, AV_LOG_ERROR, "Error while parsing dts expression '%s'\n", s->dts_str);
+            return ret;
+        }
+    }
+
+    s->frame_number= 0;
+    s->start_pts   = AV_NOPTS_VALUE;
+    s->start_dts   = AV_NOPTS_VALUE;
+    s->prev_inpts  = AV_NOPTS_VALUE;
+    s->prev_indts  = AV_NOPTS_VALUE;
+    s->prev_outpts = AV_NOPTS_VALUE;
+    s->prev_outdts = AV_NOPTS_VALUE;
+
+    return 0;
+}
+
+static int setts_filter(AVBSFContext *ctx, AVPacket *pkt)
+{
+    SetTSContext *s = ctx->priv_data;
+    int64_t new_ts, new_pts, new_dts;
+    int ret;
+
+    ret = ff_bsf_get_packet_ref(ctx, pkt);
+    if (ret < 0)
+        return ret;
+
+    if (s->start_pts == AV_NOPTS_VALUE)
+        s->start_pts = pkt->pts;
+
+    if (s->start_dts == AV_NOPTS_VALUE)
+        s->start_dts = pkt->dts;
+
+    s->var_values[VAR_N]           = s->frame_number++;
+    s->var_values[VAR_TS]          = pkt->dts;
+    s->var_values[VAR_POS]         = pkt->pos;
+    s->var_values[VAR_PTS]         = pkt->pts;
+    s->var_values[VAR_DTS]         = pkt->dts;
+    s->var_values[VAR_PREV_INPTS]  = s->prev_inpts;
+    s->var_values[VAR_PREV_INDTS]  = s->prev_indts;
+    s->var_values[VAR_PREV_OUTPTS] = s->prev_outpts;
+    s->var_values[VAR_PREV_OUTDTS] = s->prev_outdts;
+    s->var_values[VAR_STARTPTS]    = s->start_pts;
+    s->var_values[VAR_STARTDTS]    = s->start_dts;
+    s->var_values[VAR_TB]          = av_q2d(ctx->time_base_out);
+
+    new_ts = llrint(av_expr_eval(s->ts_expr, s->var_values, NULL));
+
+    if (s->pts_str) {
+        s->var_values[VAR_TS] = pkt->pts;
+        new_pts = llrint(av_expr_eval(s->pts_expr, s->var_values, NULL));
+    } else {
+        new_pts = new_ts;
+    }
+
+    if (s->dts_str) {
+        s->var_values[VAR_TS] = pkt->dts;
+        new_dts = llrint(av_expr_eval(s->dts_expr, s->var_values, NULL));
+    } else {
+        new_dts = new_ts;
+    }
+
+    s->var_values[VAR_PREV_INPTS]  = pkt->pts;
+    s->var_values[VAR_PREV_INDTS]  = pkt->dts;
+    s->var_values[VAR_PREV_OUTPTS] = new_pts;
+    s->var_values[VAR_PREV_OUTDTS] = new_dts;
+
+    pkt->pts = new_pts;
+    pkt->dts = new_dts;
+
+    return ret;
+}
+
+static void setts_close(AVBSFContext *bsf)
+{
+    SetTSContext *s = bsf->priv_data;
+
+    av_expr_free(s->ts_expr);
+    s->ts_expr = NULL;
+    av_expr_free(s->pts_expr);
+    s->pts_expr = NULL;
+    av_expr_free(s->dts_expr);
+    s->dts_expr = NULL;
+}
+
+#define OFFSET(x) offsetof(SetTSContext, x)
+#define FLAGS (AV_OPT_FLAG_VIDEO_PARAM|AV_OPT_FLAG_AUDIO_PARAM|AV_OPT_FLAG_SUBTITLE_PARAM|AV_OPT_FLAG_BSF_PARAM)
+
+static const AVOption options[] = {
+    { "ts",  "set expression for packet PTS and DTS", OFFSET(ts_str),  AV_OPT_TYPE_STRING, {.str="TS"}, 0, 0, FLAGS },
+    { "pts", "set expression for packet PTS", OFFSET(pts_str), AV_OPT_TYPE_STRING, {.str=NULL}, 0, 0, FLAGS },
+    { "dts", "set expression for packet DTS", OFFSET(dts_str), AV_OPT_TYPE_STRING, {.str=NULL}, 0, 0, FLAGS },
+    { NULL },
+};
+
+static const AVClass setts_class = {
+    .class_name = "setts_bsf",
+    .item_name  = av_default_item_name,
+    .option     = options,
+    .version    = LIBAVUTIL_VERSION_INT,
+};
+
+const AVBitStreamFilter ff_setts_bsf = {
+    .name           = "setts",
+    .priv_data_size = sizeof(SetTSContext),
+    .priv_class     = &setts_class,
+    .init           = setts_init,
+    .close          = setts_close,
+    .filter         = setts_filter,
+};

--- a/libavcodec/setts_bsf.c
+++ b/libavcodec/setts_bsf.c
@@ -43,6 +43,7 @@ static const char *const var_names[] = {
     "STARTPTS",    ///< PTS at start of movie
     "STARTDTS",    ///< DTS at start of movie
     "TB",          ///< timebase of the stream
+    "SR",          ///< sample rate of the stream
     NULL
 };
 
@@ -59,6 +60,7 @@ enum var_name {
     VAR_STARTPTS,
     VAR_STARTDTS,
     VAR_TB,
+    VAR_SR,
     VAR_VARS_NB
 };
 
@@ -151,6 +153,7 @@ static int setts_filter(AVBSFContext *ctx, AVPacket *pkt)
     s->var_values[VAR_STARTPTS]    = s->start_pts;
     s->var_values[VAR_STARTDTS]    = s->start_dts;
     s->var_values[VAR_TB]          = av_q2d(ctx->time_base_out);
+    s->var_values[VAR_SR]          = ctx->par_in->sample_rate;
 
     new_ts = llrint(av_expr_eval(s->ts_expr, s->var_values, NULL));
 

--- a/libavcodec/setts_bsf.c
+++ b/libavcodec/setts_bsf.c
@@ -171,10 +171,10 @@ static int setts_filter(AVBSFContext *ctx, AVPacket *pkt)
         new_dts = new_ts;
     }
 
-    s->var_values[VAR_PREV_INPTS]  = pkt->pts;
-    s->var_values[VAR_PREV_INDTS]  = pkt->dts;
-    s->var_values[VAR_PREV_OUTPTS] = new_pts;
-    s->var_values[VAR_PREV_OUTDTS] = new_dts;
+    s->prev_inpts  = pkt->pts;
+    s->prev_indts  = pkt->dts;
+    s->prev_outpts = new_pts;
+    s->prev_outdts = new_dts;
 
     pkt->pts = new_pts;
     pkt->dts = new_dts;

--- a/libavcodec/setts_bsf.c
+++ b/libavcodec/setts_bsf.c
@@ -44,6 +44,7 @@ static const char *const var_names[] = {
     "STARTDTS",    ///< DTS at start of movie
     "TB",          ///< timebase of the stream
     "SR",          ///< sample rate of the stream
+    "NOPTS",       ///< The AV_NOPTS_VALUE constant
     NULL
 };
 
@@ -61,6 +62,7 @@ enum var_name {
     VAR_STARTDTS,
     VAR_TB,
     VAR_SR,
+    VAR_NOPTS,
     VAR_VARS_NB
 };
 
@@ -121,6 +123,7 @@ static int setts_init(AVBSFContext *ctx)
     s->prev_indts  = AV_NOPTS_VALUE;
     s->prev_outpts = AV_NOPTS_VALUE;
     s->prev_outdts = AV_NOPTS_VALUE;
+    s->var_values[VAR_NOPTS] = AV_NOPTS_VALUE;
 
     return 0;
 }

--- a/libavcodec/setts_bsf.c
+++ b/libavcodec/setts_bsf.c
@@ -152,7 +152,7 @@ static int setts_filter(AVBSFContext *ctx, AVPacket *pkt)
     s->var_values[VAR_PREV_OUTDTS] = s->prev_outdts;
     s->var_values[VAR_STARTPTS]    = s->start_pts;
     s->var_values[VAR_STARTDTS]    = s->start_dts;
-    s->var_values[VAR_TB]          = av_q2d(ctx->time_base_out);
+    s->var_values[VAR_TB]          = ctx->time_base_out.den ? av_q2d(ctx->time_base_out) : 0;
     s->var_values[VAR_SR]          = ctx->par_in->sample_rate;
 
     new_ts = llrint(av_expr_eval(s->ts_expr, s->var_values, NULL));

--- a/libavcodec/version.h
+++ b/libavcodec/version.h
@@ -28,7 +28,7 @@
 #include "libavutil/version.h"
 
 #define LIBAVCODEC_VERSION_MAJOR  58
-#define LIBAVCODEC_VERSION_MINOR  91
+#define LIBAVCODEC_VERSION_MINOR  91  // 123, commit 48a0eb21aa (avcodec: add setts bitstream filter)
 #define LIBAVCODEC_VERSION_MICRO 100
 
 #define LIBAVCODEC_VERSION_INT  AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \

--- a/libavcodec/version.h
+++ b/libavcodec/version.h
@@ -28,7 +28,7 @@
 #include "libavutil/version.h"
 
 #define LIBAVCODEC_VERSION_MAJOR  58
-#define LIBAVCODEC_VERSION_MINOR  91  // 123, commit 48a0eb21aa (avcodec: add setts bitstream filter)
+#define LIBAVCODEC_VERSION_MINOR  91
 #define LIBAVCODEC_VERSION_MICRO 100
 
 #define LIBAVCODEC_VERSION_INT  AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \


### PR DESCRIPTION
## Links
* https://github.com/Panopto/nuget-packages/pull/32
* https://github.com/Panopto/panopto-core/pull/23744
* https://github.com/Panopto/panopto-core/pull/23756

## Description
Some of these had conflicts that I had to resolve.  Conflicts were only related to `Changelog` and `version.h`

```
git cherry-pick 48a0eb21aac062c3a65d22c48484a2420f452ec6
git cherry-pick 6941d93faab0e05acbec2bbdd014dc9c26fa0dbe
git cherry-pick 7fc8ba9068abc4c4cb3fbca4a25b53710ec374b6
git cherry-pick b0b3fce3c33352a87267b6ffa51da31d5162daff
git cherry-pick 041267b55871a5066e4acb5e29b545fede5998c9
```